### PR TITLE
feature: add settings view e2e tests

### DIFF
--- a/packages/e2e/src/settings-select-applications.ts
+++ b/packages/e2e/src/settings-select-applications.ts
@@ -10,7 +10,7 @@ export const test: Test = async ({ expect, Locator, SettingsView }) => {
   await SettingsView.selectTab('applications')
 
   // assert
-  const tab = Locator('.SettingsTab[name="applications"]')
+  const tab = Locator('.Tab[name="applications"]')
   await expect(tab).toHaveAttribute('aria-selected', 'true')
   const heading = Locator('.SettingsContentHeading')
   await expect(heading).toHaveText('Applications')

--- a/packages/e2e/src/settings-select-applications.ts
+++ b/packages/e2e/src/settings-select-applications.ts
@@ -1,19 +1,19 @@
 import type { Test } from '@lvce-editor/test-with-playwright'
 
-export const name = 'settings.select-workbench'
+export const name = 'settings.select-applications'
 
 export const test: Test = async ({ expect, Locator, SettingsView }) => {
   // arrange
   await SettingsView.show()
 
   // act
-  await SettingsView.selectTab('workbench')
+  await SettingsView.selectTab('applications')
 
   // assert
-  const tab = Locator('.SettingsTab[name="workbench"]')
+  const tab = Locator('.SettingsTab[name="applications"]')
   await expect(tab).toHaveAttribute('aria-selected', 'true')
   const heading = Locator('.SettingsContentHeading')
-  await expect(heading).toHaveText('Workbench')
-  const themeSetting = Locator('[name="theme"]')
-  await expect(themeSetting).toBeVisible()
+  await expect(heading).toHaveText('Applications')
+  const telemetrySetting = Locator('[name="telemetry"]')
+  await expect(telemetrySetting).toBeVisible()
 }

--- a/packages/e2e/src/settings-select-features.ts
+++ b/packages/e2e/src/settings-select-features.ts
@@ -1,19 +1,19 @@
 import type { Test } from '@lvce-editor/test-with-playwright'
 
-export const name = 'settings.select-workbench'
+export const name = 'settings.select-features'
 
 export const test: Test = async ({ expect, Locator, SettingsView }) => {
   // arrange
   await SettingsView.show()
 
   // act
-  await SettingsView.selectTab('workbench')
+  await SettingsView.selectTab('features')
 
   // assert
-  const tab = Locator('.SettingsTab[name="workbench"]')
+  const tab = Locator('.SettingsTab[name="features"]')
   await expect(tab).toHaveAttribute('aria-selected', 'true')
   const heading = Locator('.SettingsContentHeading')
-  await expect(heading).toHaveText('Workbench')
-  const themeSetting = Locator('[name="theme"]')
-  await expect(themeSetting).toBeVisible()
+  await expect(heading).toHaveText('Features')
+  const autoSaveSetting = Locator('[name="autoSave"]')
+  await expect(autoSaveSetting).toBeVisible()
 }

--- a/packages/e2e/src/settings-select-features.ts
+++ b/packages/e2e/src/settings-select-features.ts
@@ -10,7 +10,7 @@ export const test: Test = async ({ expect, Locator, SettingsView }) => {
   await SettingsView.selectTab('features')
 
   // assert
-  const tab = Locator('.SettingsTab[name="features"]')
+  const tab = Locator('.Tab[name="features"]')
   await expect(tab).toHaveAttribute('aria-selected', 'true')
   const heading = Locator('.SettingsContentHeading')
   await expect(heading).toHaveText('Features')

--- a/packages/e2e/src/settings-select-security.ts
+++ b/packages/e2e/src/settings-select-security.ts
@@ -1,19 +1,19 @@
 import type { Test } from '@lvce-editor/test-with-playwright'
 
-export const name = 'settings.select-workbench'
+export const name = 'settings.select-security'
 
 export const test: Test = async ({ expect, Locator, SettingsView }) => {
   // arrange
   await SettingsView.show()
 
   // act
-  await SettingsView.selectTab('workbench')
+  await SettingsView.selectTab('security')
 
   // assert
-  const tab = Locator('.SettingsTab[name="workbench"]')
+  const tab = Locator('.SettingsTab[name="security"]')
   await expect(tab).toHaveAttribute('aria-selected', 'true')
   const heading = Locator('.SettingsContentHeading')
-  await expect(heading).toHaveText('Workbench')
-  const themeSetting = Locator('[name="theme"]')
-  await expect(themeSetting).toBeVisible()
+  await expect(heading).toHaveText('Security')
+  const encryptionSetting = Locator('[name="encryption"]')
+  await expect(encryptionSetting).toBeVisible()
 }

--- a/packages/e2e/src/settings-select-security.ts
+++ b/packages/e2e/src/settings-select-security.ts
@@ -10,7 +10,7 @@ export const test: Test = async ({ expect, Locator, SettingsView }) => {
   await SettingsView.selectTab('security')
 
   // assert
-  const tab = Locator('.SettingsTab[name="security"]')
+  const tab = Locator('.Tab[name="security"]')
   await expect(tab).toHaveAttribute('aria-selected', 'true')
   const heading = Locator('.SettingsContentHeading')
   await expect(heading).toHaveText('Security')

--- a/packages/e2e/src/settings-select-workbench.ts
+++ b/packages/e2e/src/settings-select-workbench.ts
@@ -10,7 +10,7 @@ export const test: Test = async ({ expect, Locator, SettingsView }) => {
   await SettingsView.selectTab('workbench')
 
   // assert
-  const tab = Locator('.SettingsTab[name="workbench"]')
+  const tab = Locator('.Tab[name="workbench"]')
   await expect(tab).toHaveAttribute('aria-selected', 'true')
   const heading = Locator('.SettingsContentHeading')
   await expect(heading).toHaveText('Workbench')


### PR DESCRIPTION
Adds e2e coverage for the Workbench, Features, Applications, and Security settings tabs, including selected-tab state and category-specific settings.