### PR TITLE
feature: enable recommended virtual dom lint rules

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -2,6 +2,7 @@ import * as config from '@lvce-editor/eslint-config'
 
 export default [
   ...config.default,
+  ...config.recommendedVirtualDom,
   {
     rules: {
       '@typescript-eslint/prefer-readonly-parameter-types': 'off',
@@ -14,6 +15,25 @@ export default [
       'sonarjs/assertions-in-tests': 'off',
       'sonarjs/prefer-specific-assertions': 'off',
       'unicorn/no-useless-template-literals': 'off',
+    },
+  },
+  {
+    files: [
+      'packages/settings-view/src/parts/GetSettingItemsEditor/GetSettingItemsEditor.ts',
+      'packages/settings-view/src/parts/GetSettingItemsWindow/GetSettingItemsWindow.ts',
+    ],
+    rules: {
+      'virtual-dom/no-object-attribute-values': 'off',
+    },
+  },
+  {
+    files: ['packages/settings-view/test/**/*.ts'],
+    rules: {
+      'virtual-dom/no-inline-event-handlers': 'off',
+      'virtual-dom/no-object-attribute-values': 'off',
+      'virtual-dom/prefer-constants': 'off',
+      'virtual-dom/prefer-merge-class-names': 'off',
+      'virtual-dom/valid-child-count': 'off',
     },
   },
 ]

--- a/packages/settings-view/src/parts/HandleClickFilterButton/HandleClickFilterButton.ts
+++ b/packages/settings-view/src/parts/HandleClickFilterButton/HandleClickFilterButton.ts
@@ -3,7 +3,8 @@ import type { SettingsState } from '../SettingsState/SettingsState.ts'
 import { show2 } from '../ContextMenu/ContextMenu.ts'
 
 export const handleClickFilterButton = async (state: SettingsState, x: number, y: number): Promise<SettingsState> => {
-  await show2(state.id, MenuEntryId.SettingsFilter, x, y, {
+  const { id } = state
+  await show2(id, MenuEntryId.SettingsFilter, x, y, {
     menuId: MenuEntryId.SettingsFilter,
   })
   return state


### PR DESCRIPTION
Enable the shared recommended virtual DOM ESLint configuration, fix settings filter state access, and keep model-object/expected-DOM exceptions scoped to their exact source or test paths.\n\nValidated with lint, type-check, build, unit tests, and memory measurement (575,568 / 580,000 bytes).