### PR TITLE
fix: improve settings search matching

### DIFF
--- a/packages/e2e/src/settings-search.ts
+++ b/packages/e2e/src/settings-search.ts
@@ -7,7 +7,7 @@ export const test: Test = async ({ expect, Locator, SettingsView }) => {
   await SettingsView.show()
 
   // act
-  await SettingsView.handleInput('font family')
+  await SettingsView.handleInput('font-family')
 
   // assert
   const settingsItems = Locator('.SettingsItem')

--- a/packages/settings-view/src/parts/FilterBySearch/FilterBySearch.ts
+++ b/packages/settings-view/src/parts/FilterBySearch/FilterBySearch.ts
@@ -1,10 +1,26 @@
 import type { SettingItem } from '../SettingItem/SettingItem.ts'
 
+const normalizeSearchText = (value: string): string => {
+  return value
+    .replace(/([a-z\d])([A-Z])/g, '$1 $2')
+    .toLowerCase()
+    .replace(/[^a-z\d]+/g, ' ')
+    .trim()
+}
+
+const matchesSearch = (item: Readonly<SettingItem>, searchValue: string): boolean => {
+  const searchTargets = [item.heading, item.id, ...(item.aliases ?? [])]
+  return searchTargets.some((target) => normalizeSearchText(target).includes(searchValue))
+}
+
 export const filterBySearch = (items: readonly SettingItem[], searchValue: string | null): readonly SettingItem[] => {
   if (!searchValue || !searchValue.trim()) {
     return items
   }
 
-  const normalizedSearchValue = searchValue.toLowerCase().trim()
-  return items.filter((item: Readonly<SettingItem>) => item.heading.toLowerCase().includes(normalizedSearchValue))
+  const normalizedSearchValue = normalizeSearchText(searchValue)
+  if (!normalizedSearchValue) {
+    return []
+  }
+  return items.filter((item: Readonly<SettingItem>) => matchesSearch(item, normalizedSearchValue))
 }

--- a/packages/settings-view/src/parts/FilterBySearch/FilterBySearch.ts
+++ b/packages/settings-view/src/parts/FilterBySearch/FilterBySearch.ts
@@ -2,9 +2,9 @@ import type { SettingItem } from '../SettingItem/SettingItem.ts'
 
 const normalizeSearchText = (value: string): string => {
   return value
-    .replace(/([a-z\d])([A-Z])/g, '$1 $2')
+    .replaceAll(/([a-z\d])([A-Z])/g, '$1 $2')
     .toLowerCase()
-    .replace(/[^a-z\d]+/g, ' ')
+    .replaceAll(/[^a-z\d]+/g, ' ')
     .trim()
 }
 

--- a/packages/settings-view/src/parts/GetSettingItemsEditor/GetSettingItemsEditor.ts
+++ b/packages/settings-view/src/parts/GetSettingItemsEditor/GetSettingItemsEditor.ts
@@ -28,6 +28,7 @@ export const getSettingItemsEditor = (): readonly SettingItem[] => {
       value: 15,
     },
     {
+      aliases: ['editor font family'],
       category: InputName.TextEditorTab,
       description: SettingStrings.fontFamilyDescription(),
       heading: SettingStrings.fontFamily(),

--- a/packages/settings-view/src/parts/SettingItem/SettingItem.ts
+++ b/packages/settings-view/src/parts/SettingItem/SettingItem.ts
@@ -4,6 +4,7 @@ export interface SettingItemOption {
 }
 
 export interface SettingItem {
+  readonly aliases?: readonly string[]
   readonly category: string
   readonly description: string
   readonly heading: string

--- a/packages/settings-view/test/GetFilteredItems.test.ts
+++ b/packages/settings-view/test/GetFilteredItems.test.ts
@@ -141,6 +141,74 @@ test('filterBySearch should filter items case-insensitively', () => {
   expect(result[0].id).toBe('fontSize')
 })
 
+test('filterBySearch should normalize punctuation in the search value', () => {
+  const items: readonly SettingItem[] = [
+    {
+      category: InputName.TextEditorTab,
+      description: 'The font family of the editor',
+      heading: 'Font Family',
+      id: 'editor.fontFamily',
+      type: SettingItemType.String,
+      value: 'Monaco',
+    },
+  ]
+
+  const result = filterBySearch(items, 'font-family')
+  expect(result).toHaveLength(1)
+  expect(result[0].id).toBe('editor.fontFamily')
+})
+
+test('filterBySearch should filter items by id', () => {
+  const items: readonly SettingItem[] = [
+    {
+      category: InputName.TextEditorTab,
+      description: 'Controls how the cursor blinks',
+      heading: 'Cursor Blinking',
+      id: 'editor.cursorBlinking',
+      type: SettingItemType.String,
+      value: 'blink',
+    },
+  ]
+
+  const result = filterBySearch(items, 'editor cursor blinking')
+  expect(result).toHaveLength(1)
+  expect(result[0].id).toBe('editor.cursorBlinking')
+})
+
+test('filterBySearch should filter items by alias', () => {
+  const items: readonly SettingItem[] = [
+    {
+      aliases: ['typeface'],
+      category: InputName.TextEditorTab,
+      description: 'The font family of the editor',
+      heading: 'Font Family',
+      id: 'editor.fontFamily',
+      type: SettingItemType.String,
+      value: 'Monaco',
+    },
+  ]
+
+  const result = filterBySearch(items, 'typeface')
+  expect(result).toHaveLength(1)
+  expect(result[0].id).toBe('editor.fontFamily')
+})
+
+test('filterBySearch should return no items when search value is only punctuation', () => {
+  const items: readonly SettingItem[] = [
+    {
+      category: InputName.TextEditorTab,
+      description: 'The font family of the editor',
+      heading: 'Font Family',
+      id: 'editor.fontFamily',
+      type: SettingItemType.String,
+      value: 'Monaco',
+    },
+  ]
+
+  const result = filterBySearch(items, '---')
+  expect(result).toHaveLength(0)
+})
+
 test('filterBySearch should return all items when search value is empty', () => {
   const items: readonly SettingItem[] = [
     {

--- a/packages/settings-view/test/GetSettingItemsEditor.test.ts
+++ b/packages/settings-view/test/GetSettingItemsEditor.test.ts
@@ -74,6 +74,7 @@ test('getSettingItemsEditor returns expected fontFamily item', () => {
   const fontFamilyItem = items.find((item) => item.id === 'editor.fontFamily')
 
   expect(fontFamilyItem).toBeDefined()
+  expect(fontFamilyItem?.aliases).toEqual(['editor font family'])
   expect(fontFamilyItem?.heading).toBe(SettingStrings.fontFamily())
   expect(fontFamilyItem?.description).toBe(SettingStrings.fontFamilyDescription())
   expect(fontFamilyItem?.type).toBe(SettingItemType.String)


### PR DESCRIPTION
Search settings by normalized heading, setting ID, and aliases.

Add a regression for finding Editor Font Family with `font-family`.