### PR TITLE
Render directly in renderer process

### DIFF
--- a/packages/settings-view/src/parts/CommandMap/CommandMap.ts
+++ b/packages/settings-view/src/parts/CommandMap/CommandMap.ts
@@ -12,6 +12,7 @@ import { handleClickTab } from '../HandleClickTab/HandleClickTab.ts'
 import { handleInput } from '../HandleInput/HandleInput.ts'
 import { handleInputBlur } from '../HandleInputBlur/HandleInputBlur.ts'
 import { handleInputFocus } from '../HandleInputFocus/HandleInputFocus.ts'
+import { handleMessagePort } from '../HandleMessagePort/HandleMessagePort.ts'
 import { handleResizerPointerDown } from '../HandleResizerPointerDown/HandleResizerPointerDown.ts'
 import { handleResizerPointerMove } from '../HandleResizerPointerMove/HandleResizerPointerMove.ts'
 import { handleResizerPointerUp } from '../HandleResizerPointerUp/HandleResizerPointerUp.ts'
@@ -47,6 +48,7 @@ export const commandMap = {
   'Settings.handleInput': wrapCommand(handleInput),
   'Settings.handleInputBlur': wrapCommand(handleInputBlur),
   'Settings.handleInputFocus': wrapCommand(handleInputFocus),
+  'Settings.handleMessagePort': handleMessagePort,
   'Settings.handleResizerPointerDown': wrapCommand(handleResizerPointerDown),
   'Settings.handleResizerPointerMove': wrapCommand(handleResizerPointerMove),
   'Settings.handleResizerPointerUp': wrapCommand(handleResizerPointerUp),

--- a/packages/settings-view/src/parts/HandleMessagePort/HandleMessagePort.ts
+++ b/packages/settings-view/src/parts/HandleMessagePort/HandleMessagePort.ts
@@ -1,0 +1,7 @@
+import { PlainMessagePortRpc } from '@lvce-editor/rpc'
+import * as RendererProcess from '../RendererProcess/RendererProcess.ts'
+
+export const handleMessagePort = async (port: any): Promise<void> => {
+  const rpc = await PlainMessagePortRpc.create({ commandMap: {}, messagePort: port })
+  RendererProcess.set(rpc)
+}

--- a/packages/settings-view/src/parts/Render2/Render2.ts
+++ b/packages/settings-view/src/parts/Render2/Render2.ts
@@ -1,10 +1,19 @@
 import type { ViewletCommand } from '../ViewletCommand/ViewletCommand.ts'
 import * as ApplyRender from '../ApplyRender/ApplyRender.ts'
+import * as RendererProcess from '../RendererProcess/RendererProcess.ts'
 import * as SettingsStates from '../SettingsStates/SettingsStates.ts'
 
-export const render2 = (uid: number, diffResult: readonly number[]): readonly ViewletCommand[] => {
+export const render2 = (uid: number, diffResult: readonly number[]): readonly ViewletCommand[] | Promise<readonly ViewletCommand[]> => {
   const { newState, oldState } = SettingsStates.get(uid)
   SettingsStates.set(uid, newState, newState)
   const commands = ApplyRender.applyRender(oldState, newState, diffResult)
-  return commands
+  if (!RendererProcess.isConnected()) return commands
+  return renderDirect(uid, commands)
+}
+
+const renderDirect = async (uid: number, commands: readonly ViewletCommand[]): Promise<readonly ViewletCommand[]> => {
+  const rendererWorkerCommands = commands.filter((command) => command[0] === 'Viewlet.setFocusContext')
+  const rendererProcessCommands = commands.filter((command) => command[0] !== 'Viewlet.setFocusContext')
+  const transactionId = await RendererProcess.invoke('Viewlet.queueCommands', uid, rendererProcessCommands)
+  return [...rendererWorkerCommands, ['Viewlet.commitPending', uid, transactionId]]
 }

--- a/packages/settings-view/src/parts/RendererProcess/RendererProcess.ts
+++ b/packages/settings-view/src/parts/RendererProcess/RendererProcess.ts
@@ -1,0 +1,13 @@
+import type { Rpc } from '@lvce-editor/rpc'
+import { RendererProcess as RendererProcessRegistry } from '@lvce-editor/rpc-registry'
+
+const state = { connected: false }
+export const isConnected = (): boolean => {
+  const { connected } = state
+  return connected
+}
+export const invoke = (method: string, ...params: readonly unknown[]): Promise<any> => RendererProcessRegistry.invoke(method, ...params)
+export const set = (rpc: Rpc): void => {
+  RendererProcessRegistry.set(rpc)
+  state.connected = true
+}

--- a/packages/settings-view/test/HandleMessagePort.test.ts
+++ b/packages/settings-view/test/HandleMessagePort.test.ts
@@ -1,0 +1,24 @@
+import { expect, jest, test } from '@jest/globals'
+import { PlainMessagePortRpcParent } from '@lvce-editor/rpc'
+import { RendererProcess as RendererProcessRegistry } from '@lvce-editor/rpc-registry'
+import { handleMessagePort } from '../src/parts/HandleMessagePort/HandleMessagePort.ts'
+import * as RendererProcess from '../src/parts/RendererProcess/RendererProcess.ts'
+
+declare const MessageChannel: { new (): any }
+
+test('connects the view directly to the renderer process', async () => {
+  const queueCommands = jest.fn((_uid: number, _commands: readonly unknown[]) => 31)
+  const { port1, port2 } = new MessageChannel()
+  const rendererProcessRpc = await PlainMessagePortRpcParent.create({
+    commandMap: { 'Viewlet.queueCommands': queueCommands },
+    messagePort: port1,
+  })
+
+  await handleMessagePort(port2)
+  expect(RendererProcess.isConnected()).toBe(true)
+  await expect(RendererProcess.invoke('Viewlet.queueCommands', 7, [['Viewlet.setDom2', 7, []]])).resolves.toBe(31)
+  expect(queueCommands).toHaveBeenCalledWith(7, [['Viewlet.setDom2', 7, []]])
+
+  await RendererProcessRegistry.dispose()
+  await rendererProcessRpc.dispose()
+})


### PR DESCRIPTION
Route view render commands directly to the renderer process while retaining renderer-worker-only focus context updates. Adds focused coverage for the direct message-port connection.