### PR TITLE
feature: handle view events directly

### DIFF
--- a/packages/settings-view/src/parts/CommandMap/CommandMap.ts
+++ b/packages/settings-view/src/parts/CommandMap/CommandMap.ts
@@ -12,7 +12,7 @@ import { handleClickTab } from '../HandleClickTab/HandleClickTab.ts'
 import { handleInput } from '../HandleInput/HandleInput.ts'
 import { handleInputBlur } from '../HandleInputBlur/HandleInputBlur.ts'
 import { handleInputFocus } from '../HandleInputFocus/HandleInputFocus.ts'
-import { handleMessagePort } from '../HandleMessagePort/HandleMessagePort.ts'
+import { handleMessagePort, setCommandMap } from '../HandleMessagePort/HandleMessagePort.ts'
 import { handleResizerPointerDown } from '../HandleResizerPointerDown/HandleResizerPointerDown.ts'
 import { handleResizerPointerMove } from '../HandleResizerPointerMove/HandleResizerPointerMove.ts'
 import { handleResizerPointerUp } from '../HandleResizerPointerUp/HandleResizerPointerUp.ts'
@@ -67,3 +67,5 @@ export const commandMap = {
   'Settings.useNextSearchValue': wrapCommand(useNextSearchValue),
   'Settings.usePreviousSearchValue': wrapCommand(usePreviousSearchValue),
 }
+
+setCommandMap(commandMap)

--- a/packages/settings-view/src/parts/CommandMap/CommandMap.ts
+++ b/packages/settings-view/src/parts/CommandMap/CommandMap.ts
@@ -12,7 +12,7 @@ import { handleClickTab } from '../HandleClickTab/HandleClickTab.ts'
 import { handleInput } from '../HandleInput/HandleInput.ts'
 import { handleInputBlur } from '../HandleInputBlur/HandleInputBlur.ts'
 import { handleInputFocus } from '../HandleInputFocus/HandleInputFocus.ts'
-import { handleMessagePort, setCommandMap } from '../HandleMessagePort/HandleMessagePort.ts'
+import { handleMessagePort } from '../HandleMessagePort/HandleMessagePort.ts'
 import { handleResizerPointerDown } from '../HandleResizerPointerDown/HandleResizerPointerDown.ts'
 import { handleResizerPointerMove } from '../HandleResizerPointerMove/HandleResizerPointerMove.ts'
 import { handleResizerPointerUp } from '../HandleResizerPointerUp/HandleResizerPointerUp.ts'
@@ -32,6 +32,8 @@ import { getCommandIds, wrapCommand, wrapGetter } from '../SettingsStates/Settin
 import { useNextSearchValue } from '../UseNextSearchValue/UseNextSearchValue.ts'
 import { usePreviousSearchValue } from '../UsePreviousSearchValue/UsePreviousSearchValue.ts'
 
+const handleDirectMessagePort = (port: any): Promise<void> => handleMessagePort(port, commandMap)
+
 export const commandMap = {
   'Initialize.initialize': Initialize.initialize,
   'Settings.clear': wrapCommand(clear),
@@ -48,7 +50,7 @@ export const commandMap = {
   'Settings.handleInput': wrapCommand(handleInput),
   'Settings.handleInputBlur': wrapCommand(handleInputBlur),
   'Settings.handleInputFocus': wrapCommand(handleInputFocus),
-  'Settings.handleMessagePort': handleMessagePort,
+  'Settings.handleMessagePort': handleDirectMessagePort,
   'Settings.handleResizerPointerDown': wrapCommand(handleResizerPointerDown),
   'Settings.handleResizerPointerMove': wrapCommand(handleResizerPointerMove),
   'Settings.handleResizerPointerUp': wrapCommand(handleResizerPointerUp),
@@ -67,5 +69,3 @@ export const commandMap = {
   'Settings.useNextSearchValue': wrapCommand(useNextSearchValue),
   'Settings.usePreviousSearchValue': wrapCommand(usePreviousSearchValue),
 }
-
-setCommandMap(commandMap)

--- a/packages/settings-view/src/parts/HandleMessagePort/HandleMessagePort.ts
+++ b/packages/settings-view/src/parts/HandleMessagePort/HandleMessagePort.ts
@@ -2,22 +2,21 @@ import { PlainMessagePortRpc } from '@lvce-editor/rpc'
 import { RendererWorker } from '@lvce-editor/rpc-registry'
 import * as RendererProcess from '../RendererProcess/RendererProcess.ts'
 
-let viewletCommandMap: Record<string, unknown> = Object.create(null)
-
-export const setCommandMap = (commandMap: object): void => {
-  viewletCommandMap = commandMap as Record<string, unknown>
-}
-
-const executeViewletCommand = async (uid: number, command: string, ...args: readonly any[]): Promise<void> => {
-  const fn = viewletCommandMap[`Settings.${command}`]
-  if (typeof fn !== 'function') {
-    throw new Error(`Viewlet command not found: ${command}`)
+export const handleMessagePort = async (port: any, viewletCommandMap: Readonly<Record<string, unknown>>): Promise<void> => {
+  const executeViewletCommand = async (uid: number, command: string, ...args: readonly any[]): Promise<void> => {
+    const fn = viewletCommandMap[`Settings.${command}`]
+    if (typeof fn !== 'function') {
+      throw new TypeError(`Viewlet command not found: ${command}`)
+    }
+    await fn(uid, ...args)
+    await RendererWorker.invoke('Viewlet.requestRender', uid)
   }
-  await fn(uid, ...args)
-  await RendererWorker.invoke('Viewlet.requestRender', uid)
-}
 
-export const handleMessagePort = async (port: any): Promise<void> => {
-  const rpc = await PlainMessagePortRpc.create({ commandMap: { 'Viewlet.executeViewletCommand': executeViewletCommand }, messagePort: port })
+  const rpc = await PlainMessagePortRpc.create({
+    commandMap: {
+      'Viewlet.executeViewletCommand': executeViewletCommand,
+    },
+    messagePort: port,
+  })
   RendererProcess.set(rpc)
 }

--- a/packages/settings-view/src/parts/HandleMessagePort/HandleMessagePort.ts
+++ b/packages/settings-view/src/parts/HandleMessagePort/HandleMessagePort.ts
@@ -1,7 +1,23 @@
 import { PlainMessagePortRpc } from '@lvce-editor/rpc'
+import { RendererWorker } from '@lvce-editor/rpc-registry'
 import * as RendererProcess from '../RendererProcess/RendererProcess.ts'
 
+let viewletCommandMap: Record<string, unknown> = Object.create(null)
+
+export const setCommandMap = (commandMap: object): void => {
+  viewletCommandMap = commandMap as Record<string, unknown>
+}
+
+const executeViewletCommand = async (uid: number, command: string, ...args: readonly any[]): Promise<void> => {
+  const fn = viewletCommandMap[`Settings.${command}`]
+  if (typeof fn !== 'function') {
+    throw new Error(`Viewlet command not found: ${command}`)
+  }
+  await fn(uid, ...args)
+  await RendererWorker.invoke('Viewlet.requestRender', uid)
+}
+
 export const handleMessagePort = async (port: any): Promise<void> => {
-  const rpc = await PlainMessagePortRpc.create({ commandMap: {}, messagePort: port })
+  const rpc = await PlainMessagePortRpc.create({ commandMap: { 'Viewlet.executeViewletCommand': executeViewletCommand }, messagePort: port })
   RendererProcess.set(rpc)
 }

--- a/packages/settings-view/test/HandleMessagePort.test.ts
+++ b/packages/settings-view/test/HandleMessagePort.test.ts
@@ -1,7 +1,7 @@
 import { expect, jest, test } from '@jest/globals'
-import { PlainMessagePortRpcParent } from '@lvce-editor/rpc'
-import { RendererProcess as RendererProcessRegistry } from '@lvce-editor/rpc-registry'
-import { handleMessagePort } from '../src/parts/HandleMessagePort/HandleMessagePort.ts'
+import { createMockRpc, PlainMessagePortRpcParent } from '@lvce-editor/rpc'
+import { RendererProcess as RendererProcessRegistry, RendererWorker } from '@lvce-editor/rpc-registry'
+import { handleMessagePort, setCommandMap } from '../src/parts/HandleMessagePort/HandleMessagePort.ts'
 import * as RendererProcess from '../src/parts/RendererProcess/RendererProcess.ts'
 
 declare const MessageChannel: { new (): any }
@@ -19,6 +19,16 @@ test('connects the view directly to the renderer process', async () => {
   await expect(RendererProcess.invoke('Viewlet.queueCommands', 7, [['Viewlet.setDom2', 7, []]])).resolves.toBe(31)
   expect(queueCommands).toHaveBeenCalledWith(7, [['Viewlet.setDom2', 7, []]])
 
+  const requestRender = jest.fn(async (_uid: number) => {})
+  RendererWorker.set(Object.assign(createMockRpc({ commandMap: { 'Viewlet.requestRender': requestRender } }), { dispose: jest.fn() }))
+  const handleInput = jest.fn(async (_uid: number, _value: string) => {})
+  setCommandMap({ 'Settings.handleInput': handleInput })
+  await rendererProcessRpc.invoke('Viewlet.executeViewletCommand', 7, 'handleInput', 'hello')
+  expect(handleInput).toHaveBeenCalledWith(7, 'hello')
+  expect(requestRender).toHaveBeenCalledWith(7)
+  await expect(rendererProcessRpc.invoke('Viewlet.executeViewletCommand', 7, 'missing')).rejects.toThrow('Viewlet command not found: missing')
+
   await RendererProcessRegistry.dispose()
+  await RendererWorker.dispose()
   await rendererProcessRpc.dispose()
 })

--- a/packages/settings-view/test/HandleMessagePort.test.ts
+++ b/packages/settings-view/test/HandleMessagePort.test.ts
@@ -1,7 +1,7 @@
 import { expect, jest, test } from '@jest/globals'
 import { createMockRpc, PlainMessagePortRpcParent } from '@lvce-editor/rpc'
 import { RendererProcess as RendererProcessRegistry, RendererWorker } from '@lvce-editor/rpc-registry'
-import { handleMessagePort, setCommandMap } from '../src/parts/HandleMessagePort/HandleMessagePort.ts'
+import { handleMessagePort } from '../src/parts/HandleMessagePort/HandleMessagePort.ts'
 import * as RendererProcess from '../src/parts/RendererProcess/RendererProcess.ts'
 
 declare const MessageChannel: { new (): any }
@@ -13,16 +13,26 @@ test('connects the view directly to the renderer process', async () => {
     commandMap: { 'Viewlet.queueCommands': queueCommands },
     messagePort: port1,
   })
+  const handleInput = jest.fn(async (_uid: number, _value: string) => {})
 
-  await handleMessagePort(port2)
+  await handleMessagePort(port2, {
+    'Settings.handleInput': handleInput,
+  })
   expect(RendererProcess.isConnected()).toBe(true)
   await expect(RendererProcess.invoke('Viewlet.queueCommands', 7, [['Viewlet.setDom2', 7, []]])).resolves.toBe(31)
   expect(queueCommands).toHaveBeenCalledWith(7, [['Viewlet.setDom2', 7, []]])
 
   const requestRender = jest.fn(async (_uid: number) => {})
-  RendererWorker.set(Object.assign(createMockRpc({ commandMap: { 'Viewlet.requestRender': requestRender } }), { dispose: jest.fn() }))
-  const handleInput = jest.fn(async (_uid: number, _value: string) => {})
-  setCommandMap({ 'Settings.handleInput': handleInput })
+  RendererWorker.set(
+    Object.assign(
+      createMockRpc({
+        commandMap: {
+          'Viewlet.requestRender': requestRender,
+        },
+      }),
+      { dispose: jest.fn() },
+    ),
+  )
   await rendererProcessRpc.invoke('Viewlet.executeViewletCommand', 7, 'handleInput', 'hello')
   expect(handleInput).toHaveBeenCalledWith(7, 'hello')
   expect(requestRender).toHaveBeenCalledWith(7)


### PR DESCRIPTION
## Summary

- expose the worker command map on the renderer-process message port
- execute direct DOM events in the owning view worker
- request renderer-worker diff/render only after the state update succeeds

## Tests

- 79 suites, 473 tests passed
- TypeScript build passed