### PR TITLE
feature: support secondary direct view connections

### DIFF
--- a/packages/settings-view/src/parts/CommandMap/CommandMap.ts
+++ b/packages/settings-view/src/parts/CommandMap/CommandMap.ts
@@ -32,7 +32,7 @@ import { getCommandIds, wrapCommand, wrapGetter } from '../SettingsStates/Settin
 import { useNextSearchValue } from '../UseNextSearchValue/UseNextSearchValue.ts'
 import { usePreviousSearchValue } from '../UsePreviousSearchValue/UsePreviousSearchValue.ts'
 
-const handleDirectMessagePort = (port: any): Promise<void> => handleMessagePort(port, commandMap)
+const handleDirectMessagePort = (port: any, setAsRendererProcess = true): Promise<void> => handleMessagePort(port, commandMap, setAsRendererProcess)
 
 export const commandMap = {
   'Initialize.initialize': Initialize.initialize,

--- a/packages/settings-view/src/parts/HandleMessagePort/HandleMessagePort.ts
+++ b/packages/settings-view/src/parts/HandleMessagePort/HandleMessagePort.ts
@@ -2,7 +2,11 @@ import { PlainMessagePortRpc } from '@lvce-editor/rpc'
 import { RendererWorker } from '@lvce-editor/rpc-registry'
 import * as RendererProcess from '../RendererProcess/RendererProcess.ts'
 
-export const handleMessagePort = async (port: any, viewletCommandMap: Readonly<Record<string, unknown>>): Promise<void> => {
+export const handleMessagePort = async (
+  port: any,
+  viewletCommandMap: Readonly<Record<string, unknown>>,
+  setAsRendererProcess = true,
+): Promise<void> => {
   const executeViewletCommand = async (uid: number, command: string, ...args: readonly any[]): Promise<void> => {
     const fn = viewletCommandMap[`Settings.${command}`]
     if (typeof fn !== 'function') {
@@ -18,5 +22,7 @@ export const handleMessagePort = async (port: any, viewletCommandMap: Readonly<R
     },
     messagePort: port,
   })
-  RendererProcess.set(rpc)
+  if (setAsRendererProcess) {
+    RendererProcess.set(rpc)
+  }
 }

--- a/packages/settings-view/test/HandleMessagePort.test.ts
+++ b/packages/settings-view/test/HandleMessagePort.test.ts
@@ -42,3 +42,25 @@ test('connects the view directly to the renderer process', async () => {
   await RendererWorker.dispose()
   await rendererProcessRpc.dispose()
 })
+
+test('keeps the renderer process rpc for a secondary direct connection', async () => {
+  const queueCommands = jest.fn((_uid: number, _commands: readonly unknown[]) => 31)
+  RendererProcessRegistry.set(
+    Object.assign(
+      createMockRpc({
+        commandMap: { 'Viewlet.queueCommands': queueCommands },
+      }),
+      { dispose: jest.fn() },
+    ),
+  )
+  const { port1, port2 } = new MessageChannel()
+
+  await handleMessagePort(port2, {}, false)
+
+  expect(RendererProcess.invoke('Viewlet.queueCommands', 7, [])).toBe(31)
+  expect(queueCommands).toHaveBeenCalledWith(7, [])
+
+  port1.close()
+  port2.close()
+  await RendererProcessRegistry.dispose()
+})


### PR DESCRIPTION
## Summary
- accept a secondary direct MessagePort for Test Worker events
- preserve the existing Renderer Process RPC on secondary connections
- continue requesting render diffs through Renderer Worker

## Tests
- npm run type-check
- focused HandleMessagePort tests