### PR TITLE
feature: load settings data in parallel

### DIFF
--- a/packages/settings-view/src/parts/LoadContent/LoadContent.ts
+++ b/packages/settings-view/src/parts/LoadContent/LoadContent.ts
@@ -1,5 +1,4 @@
 import type { ModifiedSettings } from '../ModifiedSettings/ModifiedSettings.ts'
-import type { SettingItem } from '../SettingItem/SettingItem.ts'
 import type { SettingsState } from '../SettingsState/SettingsState.ts'
 import { computeScrollBar } from '../ComputeScrollBar/ComputeScrollBar.ts'
 import { computeVisibleItems } from '../ComputeVisibleItems/ComputeVisibleItems.ts'
@@ -16,8 +15,7 @@ export const loadContent = async (state: SettingsState, savedState: unknown): Pr
   const { history, historyIndex, scrollOffset, searchValue, sideBarWidth, tabId } = restoreState(savedState)
   const tabs = await getTabs()
   const newTabs = getUpdatedTabs(tabs, tabId)
-  const items: readonly SettingItem[] = await getSettingItems()
-  const preferences = await getPreferences()
+  const [items, preferences] = await Promise.all([getSettingItems(), getPreferences()])
   const modifiedSettings: ModifiedSettings = getModifiedSettings(preferences)
   const filteredItems = getFilteredItems(items, newTabs, searchValue, modifiedSettings, preferences)
   const { height, itemHeight } = state

--- a/packages/settings-view/test/LoadContent.test.ts
+++ b/packages/settings-view/test/LoadContent.test.ts
@@ -307,16 +307,16 @@ test('loadContent should use preferences from RendererWorker', async () => {
 
 test('loadContent should load setting items and preferences in parallel', async () => {
   const events: string[] = []
+  const { promise: itemsCanFinish, resolve: resolveItems } = Promise.withResolvers<void>()
   SettingsWorker.set(
     MockRpc.create({
       commandMap: {},
-      invoke(method: string) {
+      async invoke(method: string) {
         if (method === 'SettingsWorker.getSettingsItems2') {
           events.push('items-started')
-          return Promise.resolve().then(() => {
-            events.push('items-finished')
-            return items
-          })
+          await itemsCanFinish
+          events.push('items-finished')
+          return items
         }
         if (method === 'SettingsWorker.getTabs') {
           return tabs
@@ -331,6 +331,7 @@ test('loadContent should load setting items and preferences in parallel', async 
       invoke(method: string) {
         if (method === 'Preferences.getAll') {
           events.push('preferences-started')
+          resolveItems()
           return {}
         }
         throw new Error(`unexpected method ${method}`)

--- a/packages/settings-view/test/LoadContent.test.ts
+++ b/packages/settings-view/test/LoadContent.test.ts
@@ -305,6 +305,44 @@ test('loadContent should use preferences from RendererWorker', async () => {
   })
 })
 
+test('loadContent should load setting items and preferences in parallel', async () => {
+  const events: string[] = []
+  SettingsWorker.set(
+    MockRpc.create({
+      commandMap: {},
+      invoke(method: string) {
+        if (method === 'SettingsWorker.getSettingsItems2') {
+          events.push('items-started')
+          return Promise.resolve().then(() => {
+            events.push('items-finished')
+            return items
+          })
+        }
+        if (method === 'SettingsWorker.getTabs') {
+          return tabs
+        }
+        throw new Error(`unexpected method ${method}`)
+      },
+    }),
+  )
+  RendererWorker.set(
+    MockRpc.create({
+      commandMap: {},
+      invoke(method: string) {
+        if (method === 'Preferences.getAll') {
+          events.push('preferences-started')
+          return {}
+        }
+        throw new Error(`unexpected method ${method}`)
+      },
+    }),
+  )
+
+  await loadContent(createDefaultState(), null)
+
+  expect(events).toEqual(['items-started', 'preferences-started', 'items-finished'])
+})
+
 test('loadContent should handle empty preferences', async () => {
   const mockRpc = MockRpc.create({
     commandMap: {},


### PR DESCRIPTION
Load settings items and preferences concurrently when opening the Settings view, reducing initialization latency. Adds regression coverage for the parallel request ordering.