### PR TITLE
Fix settings filter menu actions

### DIFF
--- a/packages/e2e/src/settings-filter-menu-open.ts
+++ b/packages/e2e/src/settings-filter-menu-open.ts
@@ -2,16 +2,26 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'settings.filter-menu-open'
 
-export const skip = 1
+export const skip = 1 // Requires the settings-worker renderer integration.
 
-export const test: Test = async ({ Command, expect, Locator, SettingsView }) => {
+export const test: Test = async ({ ContextMenu, expect, Locator, SettingsView }) => {
   // arrange
   await SettingsView.show()
 
   // act
-  await Command.execute('Settings.handleClickFilterButton')
+  await SettingsView.handleClickFilterButton(700, 100)
 
   // assert
   const contextMenu = Locator('.Menu')
   await expect(contextMenu).toBeVisible()
+  const menuItems = contextMenu.locator('.MenuItem')
+  await expect(menuItems).toHaveCount(10)
+
+  // act
+  await ContextMenu.selectItem('Modified')
+
+  // assert
+  const input = Locator('.SettingsSearchInput')
+  await expect(input).toHaveValue('@modified')
+  await expect(input).toBeFocused()
 }

--- a/packages/settings-view/src/parts/CommandMap/CommandMap.ts
+++ b/packages/settings-view/src/parts/CommandMap/CommandMap.ts
@@ -3,6 +3,7 @@ import { clear } from '../Clear/Clear.ts'
 import { clearHistory } from '../ClearHistory/ClearHistory.ts'
 import * as Create from '../Create/Create.ts'
 import * as Diff2 from '../Diff2/Diff2.ts'
+import * as Filter from '../Filter/Filter.ts'
 import { getKeyBindings } from '../GetKeyBindings/GetKeyBindings.ts'
 import { getMenuEntries2 } from '../GetMenuEntries2/GetMenuEntries2.ts'
 import { getMenuIds } from '../GetMenuIds/GetMenuIds.ts'
@@ -42,6 +43,16 @@ export const commandMap = {
   'Settings.clearHistory': wrapCommand(clearHistory),
   'Settings.create': Create.create,
   'Settings.diff2': Diff2.diff2,
+  'Settings.filter.advanced': wrapCommand(Filter.filterAdvanced),
+  'Settings.filter.experimental': wrapCommand(Filter.filterExperimental),
+  'Settings.filter.extensionId': wrapCommand(Filter.filterExtensionId),
+  'Settings.filter.feature': wrapCommand(Filter.filterFeature),
+  'Settings.filter.language': wrapCommand(Filter.filterLanguage),
+  'Settings.filter.modified': wrapCommand(Filter.filterModified),
+  'Settings.filter.preview': wrapCommand(Filter.filterPreview),
+  'Settings.filter.settingId': wrapCommand(Filter.filterSettingId),
+  'Settings.filter.stable': wrapCommand(Filter.filterStable),
+  'Settings.filter.tag': wrapCommand(Filter.filterTag),
   'Settings.getCommandIds': getCommandIds,
   'Settings.getKeyBindings': getKeyBindings,
   'Settings.getMenuEntries': wrapGetter(getMenuEntries2),

--- a/packages/settings-view/src/parts/Filter/Filter.ts
+++ b/packages/settings-view/src/parts/Filter/Filter.ts
@@ -1,0 +1,58 @@
+import type { SettingsState } from '../SettingsState/SettingsState.ts'
+import { handleInput } from '../HandleInput/HandleInput.ts'
+import { Script } from '../InputSource/InputSource.ts'
+import * as WhenExpression from '../WhenExpression/WhenExpression.ts'
+
+const applyFilter = (state: SettingsState, searchValue: string): SettingsState => {
+  const newState = handleInput(state, searchValue, Script)
+  return {
+    ...newState,
+    focus: WhenExpression.FocusSettingsInput,
+    focusSource: Script,
+  }
+}
+
+const appendFilter = (state: SettingsState, filter: string): SettingsState => {
+  const { searchValue: currentSearchValue } = state
+  const searchValue = currentSearchValue.trimEnd()
+  const newSearchValue = searchValue ? `${searchValue} ${filter}` : filter
+  return applyFilter(state, newSearchValue)
+}
+
+const toggleFilter = (state: SettingsState, filter: string): SettingsState => {
+  const { searchValue } = state
+  const words = searchValue.split(' ')
+  const newSearchValue = words.includes(filter) ? words.filter((word) => word !== filter).join(' ') : [...words.filter(Boolean), filter].join(' ')
+  return applyFilter(state, newSearchValue)
+}
+
+const toggleExclusiveFilter = (state: SettingsState, filter: string, excludedFilters: readonly string[]): SettingsState => {
+  const { searchValue } = state
+  const words = searchValue.split(' ')
+  if (words.includes(filter)) {
+    return applyFilter(state, words.filter((word) => word !== filter).join(' '))
+  }
+  const newSearchValue = [...words.filter((word) => word && word !== filter && !excludedFilters.includes(word)), filter].join(' ')
+  return applyFilter(state, newSearchValue)
+}
+
+export const filterAdvanced = (state: SettingsState): SettingsState => toggleFilter(state, '@tag:advanced')
+
+export const filterExperimental = (state: SettingsState): SettingsState =>
+  toggleExclusiveFilter(state, '@tag:experimental', ['@stable', '@tag:preview'])
+
+export const filterExtensionId = (state: SettingsState): SettingsState => appendFilter(state, '@ext:')
+
+export const filterFeature = (state: SettingsState): SettingsState => appendFilter(state, '@feature:')
+
+export const filterLanguage = (state: SettingsState): SettingsState => appendFilter(state, '@lang:')
+
+export const filterModified = (state: SettingsState): SettingsState => toggleFilter(state, '@modified')
+
+export const filterPreview = (state: SettingsState): SettingsState => toggleExclusiveFilter(state, '@tag:preview', ['@stable', '@tag:experimental'])
+
+export const filterSettingId = (state: SettingsState): SettingsState => appendFilter(state, '@id:')
+
+export const filterStable = (state: SettingsState): SettingsState => toggleExclusiveFilter(state, '@stable', ['@tag:preview', '@tag:experimental'])
+
+export const filterTag = (state: SettingsState): SettingsState => appendFilter(state, '@tag:')

--- a/packages/settings-view/src/parts/GetFilteredItems/GetFilteredItems.ts
+++ b/packages/settings-view/src/parts/GetFilteredItems/GetFilteredItems.ts
@@ -5,6 +5,7 @@ import type { SettingItem } from '../SettingItem/SettingItem.ts'
 import type { Tab } from '../Tab/Tab.ts'
 import { filterBySearch } from '../FilterBySearch/FilterBySearch.ts'
 import { filterByTab } from '../FilterByTab/FilterByTab.ts'
+import { parseFilterQuery } from '../ParseFilterQuery/ParseFilterQuery.ts'
 import { validateSettings } from '../ValidateSettings/ValidateSettings.ts'
 
 export const getFilteredItems = (
@@ -14,8 +15,9 @@ export const getFilteredItems = (
   modifiedSettings: ModifiedSettings,
   preferences: Preferences,
 ): readonly DisplaySettingItem[] => {
+  const parsedQuery = parseFilterQuery(searchValue)
   const tabFilteredItems = filterByTab(items, tabs)
-  const searchFilteredItems = filterBySearch(tabFilteredItems, searchValue)
+  const searchFilteredItems = filterBySearch(tabFilteredItems, parsedQuery.query)
   const validated = validateSettings(searchFilteredItems, modifiedSettings, preferences)
-  return validated
+  return parsedQuery.modified ? validated.filter((item) => item.modified) : validated
 }

--- a/packages/settings-view/src/parts/ParseFilterQuery/ParseFilterQuery.ts
+++ b/packages/settings-view/src/parts/ParseFilterQuery/ParseFilterQuery.ts
@@ -1,10 +1,16 @@
 import type { ParsedFilterQuery } from '../ParsedFilterQuery/ParsedFilterQuery.ts'
 
 export const parseFilterQuery = (searchValue: string): ParsedFilterQuery => {
+  const words = searchValue.split(/\s+/)
+  const modified = words.includes('@modified')
+  const query = words
+    .filter((word) => word !== '@modified')
+    .join(' ')
+    .trim()
   return {
     id: '',
     language: '',
-    modified: false,
-    query: searchValue,
+    modified,
+    query,
   }
 }

--- a/packages/settings-view/test/Filter.test.ts
+++ b/packages/settings-view/test/Filter.test.ts
@@ -1,0 +1,70 @@
+import { expect, test } from '@jest/globals'
+import { createDefaultState } from '../src/parts/CreateDefaultState/CreateDefaultState.ts'
+import {
+  filterAdvanced,
+  filterExperimental,
+  filterExtensionId,
+  filterFeature,
+  filterLanguage,
+  filterModified,
+  filterPreview,
+  filterSettingId,
+  filterStable,
+  filterTag,
+} from '../src/parts/Filter/Filter.ts'
+import { Script } from '../src/parts/InputSource/InputSource.ts'
+import * as WhenExpression from '../src/parts/WhenExpression/WhenExpression.ts'
+
+test.each([
+  [filterAdvanced, '@tag:advanced'],
+  [filterExperimental, '@tag:experimental'],
+  [filterExtensionId, '@ext:'],
+  [filterFeature, '@feature:'],
+  [filterLanguage, '@lang:'],
+  [filterModified, '@modified'],
+  [filterPreview, '@tag:preview'],
+  [filterSettingId, '@id:'],
+  [filterStable, '@stable'],
+  [filterTag, '@tag:'],
+])('filter command applies %s', (filterCommand, expectedSearchValue) => {
+  const result = filterCommand(createDefaultState())
+
+  expect(result.searchValue).toBe(expectedSearchValue)
+  expect(result.inputSource).toBe(Script)
+  expect(result.focus).toBe(WhenExpression.FocusSettingsInput)
+  expect(result.focusSource).toBe(Script)
+})
+
+test.each([
+  [filterAdvanced, '@tag:advanced'],
+  [filterExperimental, '@tag:experimental'],
+  [filterModified, '@modified'],
+  [filterPreview, '@tag:preview'],
+  [filterStable, '@stable'],
+])('filter command toggles %s', (filterCommand, searchValue) => {
+  const state = { ...createDefaultState(), searchValue: `font ${searchValue}` }
+
+  const result = filterCommand(state)
+
+  expect(result.searchValue).toBe('font')
+})
+
+test.each([
+  [filterExperimental, '@tag:experimental', 'font @stable @tag:preview'],
+  [filterPreview, '@tag:preview', 'font @stable @tag:experimental'],
+  [filterStable, '@stable', 'font @tag:preview @tag:experimental'],
+])('release-channel filter %s replaces mutually exclusive filters', (filterCommand, expectedSearchValue, initialSearchValue) => {
+  const state = { ...createDefaultState(), searchValue: initialSearchValue }
+
+  const result = filterCommand(state)
+
+  expect(result.searchValue).toBe(`font ${expectedSearchValue}`)
+})
+
+test('append filter preserves the existing query', () => {
+  const state = { ...createDefaultState(), searchValue: 'font ' }
+
+  const result = filterSettingId(state)
+
+  expect(result.searchValue).toBe('font @id:')
+})

--- a/packages/settings-view/test/GetFilteredItems.test.ts
+++ b/packages/settings-view/test/GetFilteredItems.test.ts
@@ -306,3 +306,30 @@ test('getFilteredItems should combine all operations correctly and return Displa
   expect(result[1].hasError).toBe(false)
   expect(result[1].errorMessage).toBe('')
 })
+
+test('getFilteredItems should filter modified settings', () => {
+  const items: readonly SettingItem[] = [
+    {
+      category: InputName.TextEditorTab,
+      description: 'The font size of the editor',
+      heading: 'Font Size',
+      id: 'editor.fontSize',
+      type: SettingItemType.Number,
+      value: 15,
+    },
+    {
+      category: InputName.TextEditorTab,
+      description: 'The font family of the editor',
+      heading: 'Font Family',
+      id: 'editor.fontFamily',
+      type: SettingItemType.String,
+      value: 'Monaco',
+    },
+  ]
+
+  const result = getFilteredItems(items, [], '@modified font', { 'editor.fontSize': true }, { 'editor.fontSize': 16 })
+
+  expect(result).toHaveLength(1)
+  expect(result[0].id).toBe('editor.fontSize')
+  expect(result[0].modified).toBe(true)
+})

--- a/packages/settings-view/test/GetMenuEntries.test.ts
+++ b/packages/settings-view/test/GetMenuEntries.test.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@jest/globals'
+import { commandMap } from '../src/parts/CommandMap/CommandMap.ts'
 import { getMenuEntries } from '../src/parts/GetMenuEntries/GetMenuEntries.ts'
 import * as SettingStrings from '../src/parts/SettingStrings/SettingStrings.ts'
 
@@ -69,4 +70,11 @@ test('getMenuEntries returns entries in correct order', () => {
   expect(menuEntries[7].id).toBe('filter-settingId')
   expect(menuEntries[8].id).toBe('filter-stable')
   expect(menuEntries[9].id).toBe('filter-tag')
+})
+
+test('every menu entry references a registered command', () => {
+  const menuEntries = getMenuEntries()
+  for (const entry of menuEntries) {
+    expect(Object.hasOwn(commandMap, entry.command)).toBe(true)
+  }
 })

--- a/packages/settings-view/test/ParseFilterQuery.test.ts
+++ b/packages/settings-view/test/ParseFilterQuery.test.ts
@@ -1,0 +1,14 @@
+import { expect, test } from '@jest/globals'
+import { parseFilterQuery } from '../src/parts/ParseFilterQuery/ParseFilterQuery.ts'
+
+test('parses an empty query', () => {
+  expect(parseFilterQuery('')).toEqual({ id: '', language: '', modified: false, query: '' })
+})
+
+test('parses the modified filter', () => {
+  expect(parseFilterQuery('font @modified family')).toEqual({ id: '', language: '', modified: true, query: 'font family' })
+})
+
+test('does not parse partial modified filter matches', () => {
+  expect(parseFilterQuery('@modifiedElse')).toEqual({ id: '', language: '', modified: false, query: '@modifiedElse' })
+})


### PR DESCRIPTION
## Summary

- register and implement every Settings filter-menu command
- make the Modified query filter visible settings while preserving text search
- add unit coverage and extend the gated settings filter-menu e2e scenario

## Tests

- `npm test --workspace=@lvce-editor/settings-view -- --runInBand`
- `npm run type-check`
- `npm run lint`
- `npm run build`