### PR TITLE
Anchor settings filter menu for keyboard activation

### DIFF
--- a/packages/settings-view/src/parts/HandleClickFilterButton/HandleClickFilterButton.ts
+++ b/packages/settings-view/src/parts/HandleClickFilterButton/HandleClickFilterButton.ts
@@ -2,9 +2,25 @@ import { MenuEntryId } from '@lvce-editor/constants'
 import type { SettingsState } from '../SettingsState/SettingsState.ts'
 import { show2 } from '../ContextMenu/ContextMenu.ts'
 
-export const handleClickFilterButton = async (state: SettingsState, x: number, y: number): Promise<SettingsState> => {
+const filterButtonWidth = 20
+const searchFieldHeight = 26
+const settingsHeaderPaddingRight = 24
+const settingsHeaderPaddingTop = 14
+
+const getMenuPosition = (state: SettingsState, eventX: number, eventY: number): readonly [number, number] => {
+  if (eventX !== 0 || eventY !== 0) {
+    return [eventX, eventY]
+  }
+  const { width, x, y } = state
+  const menuX = x + width - settingsHeaderPaddingRight - filterButtonWidth / 2
+  const menuY = y + settingsHeaderPaddingTop + searchFieldHeight / 2
+  return [menuX, menuY]
+}
+
+export const handleClickFilterButton = async (state: SettingsState, eventX: number, eventY: number): Promise<SettingsState> => {
   const { id } = state
-  await show2(id, MenuEntryId.SettingsFilter, x, y, {
+  const [menuX, menuY] = getMenuPosition(state, eventX, eventY)
+  await show2(id, MenuEntryId.SettingsFilter, menuX, menuY, {
     menuId: MenuEntryId.SettingsFilter,
   })
   return state

--- a/packages/settings-view/test/HandleClickFilterButton.test.ts
+++ b/packages/settings-view/test/HandleClickFilterButton.test.ts
@@ -1,40 +1,36 @@
 import { expect, test } from '@jest/globals'
-import { MockRpc } from '@lvce-editor/rpc'
+import { MenuEntryId } from '@lvce-editor/constants'
 import { RendererWorker } from '@lvce-editor/rpc-registry'
 import type { SettingsState } from '../src/parts/SettingsState/SettingsState.ts'
 import { createDefaultState } from '../src/parts/CreateDefaultState/CreateDefaultState.ts'
 import { handleClickFilterButton } from '../src/parts/HandleClickFilterButton/HandleClickFilterButton.ts'
 
-test('handleClickFilterButton returns the state', async () => {
-  const mockRpc = MockRpc.create({
-    commandMap: {},
-    invoke: (method: string) => {
-      if (method.includes('showContextMenu') || method.includes('ContextMenu')) {
-        return undefined
-      }
-      throw new Error(`unexpected method ${method}`)
-    },
+test('handleClickFilterButton uses pointer coordinates', async () => {
+  using mockRpc = RendererWorker.registerMockRpc({
+    'ContextMenu.show2'() {},
   })
-  RendererWorker.set(mockRpc)
 
-  const state: SettingsState = createDefaultState()
+  const state: SettingsState = { ...createDefaultState(), id: 123 }
   const result = await handleClickFilterButton(state, 100, 200)
-  expect(result).toEqual(state)
+
+  expect(result).toBe(state)
+  expect(mockRpc.invocations).toEqual([['ContextMenu.show2', 123, MenuEntryId.SettingsFilter, 100, 200, { menuId: MenuEntryId.SettingsFilter }]])
 })
 
-test('handleClickFilterButton returns same state object', async () => {
-  const mockRpc = MockRpc.create({
-    commandMap: {},
-    invoke: (method: string) => {
-      if (method.includes('showContextMenu') || method.includes('ContextMenu')) {
-        return undefined
-      }
-      throw new Error(`unexpected method ${method}`)
-    },
+test('handleClickFilterButton derives the filter-button position for keyboard clicks', async () => {
+  using mockRpc = RendererWorker.registerMockRpc({
+    'ContextMenu.show2'() {},
   })
-  RendererWorker.set(mockRpc)
 
-  const state: SettingsState = createDefaultState()
-  const result = await handleClickFilterButton(state, 100, 200)
+  const state: SettingsState = {
+    ...createDefaultState(),
+    id: 456,
+    width: 800,
+    x: 100,
+    y: 200,
+  }
+  const result = await handleClickFilterButton(state, 0, 0)
+
   expect(result).toBe(state)
+  expect(mockRpc.invocations).toEqual([['ContextMenu.show2', 456, MenuEntryId.SettingsFilter, 866, 227, { menuId: MenuEntryId.SettingsFilter }]])
 })


### PR DESCRIPTION
## Summary

- detect the zero coordinates produced by keyboard-generated button clicks
- derive a stable filter-button anchor from the current Settings view bounds
- preserve pointer coordinates unchanged and cover both paths at the context-menu boundary

## Tests

- `npm test --workspace=@lvce-editor/settings-view -- --runInBand`
- `npm run type-check`
- `npm run lint`
- `npm run build`